### PR TITLE
fix: Add missing import for base64 package

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"


### PR DESCRIPTION
This commit fixes a build failure in the GitHub Actions workflow. The error `undefined: base64` was caused by using the `base64` package in the `translateMessages` function without importing it.

This change adds `"encoding/base64"` to the import block in `main.go`.