### PR TITLE
fix: Remove unused imports

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -9,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 )


### PR DESCRIPTION
This commit fixes a build failure in the GitHub Actions workflow. The Go compiler was correctly reporting errors for the `bufio` and `regexp` packages being imported but not used.

This was a result of a previous refactoring that simplified the response handling logic, making these packages obsolete. This change removes the unnecessary import statements.