### PR TITLE
fix: Add missing header constants

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,9 +27,12 @@ var (
 const (
 	X_FE_VERSION     = "prod-fe-1.0.70"
 	BROWSER_UA       = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 Edg/139.0.0.0"
+	SEC_CH_UA        = "\"Not;A=Brand\";v=\"99\", \"Microsoft Edge\";v=\"139\", \"Chromium\";v=\"139\""
+	SEC_CH_UA_MOB    = "?0"
+	SEC_CH_UA_PLAT   = "\"Windows\""
 	ORIGIN_BASE      = "https://chat.z.ai"
 	ANON_TOKEN_ENABLED = true
-	THINK_TAGS_MODE = "strip"
+	THINK_TAGS_MODE    = "strip"
 )
 
 // Init config from environment variables


### PR DESCRIPTION
This commit fixes a build failure where the compiler reported undefined constants (`SEC_CH_UA`, etc.).

These constants were used in the `callUpstream` function to set browser-like headers, but their definitions were accidentally removed during a previous refactoring. This change restores the constant definitions.